### PR TITLE
Enable -Wall for executable

### DIFF
--- a/app/Build.hs
+++ b/app/Build.hs
@@ -34,7 +34,7 @@ import Data.Foldable (for_)
 import Control.Monad (forM)
 import Data.List (intersperse,nub)
 import System.Directory (removeDirectoryRecursive, createDirectoryIfMissing)
-import System.FilePath ((</>), takeExtension, splitDirectories, joinPath)
+import System.FilePath (takeExtension, splitDirectories, joinPath)
 import System.Process (rawSystem)
 import Text.Printf (printf)
 
@@ -65,7 +65,7 @@ build shouldDist shouldPreprocess directories = do
           createDirectoryIfMissing True preprocessedPath
           let modulePaths = filter isHaskellFile filePaths
           forM modulePaths (\path -> do
-            rawSystem "ghc" [
+            _ <- rawSystem "ghc" [
               "-E",
               "-optP","-P",
               "-optL","-P",

--- a/app/CreateEnv.hs
+++ b/app/CreateEnv.hs
@@ -23,7 +23,7 @@ import System.Directory (
   listDirectory, doesFileExist, copyFile, createDirectoryIfMissing)
 import System.FilePath ((</>), takeFileName)
 import Control.Monad (
-  forM, filterM)
+  forM, forM_, filterM)
 
 createEnv :: IO ()
 createEnv = do
@@ -50,7 +50,7 @@ createCbits = do
   putStrLn "Initializing .fragnix/cbits ..."
   cfiles <- getCFiles
   createDirectoryIfMissing True cbitsPath
-  forM cfiles $ \file -> do
+  forM_ cfiles $ \file -> do
     putStrLn $ "   Copying " ++ file ++ "..."
     copyFile ("builtins" </> "cbits" </> file) (cbitsPath </> file)
   return ()
@@ -68,7 +68,7 @@ createInclude = do
   putStrLn "Initializing .fragnix/include ..."
   hfiles <- getHFiles
   createDirectoryIfMissing True includePath
-  forM hfiles $ \file -> do
+  forM_ hfiles $ \file -> do
     putStrLn $ "   Copying " ++ file ++ "..."
     copyFile ("builtins" </> "include" </> file) (includePath </> file)
   return ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,7 +12,7 @@ import Options.Applicative (
   ParserInfo, Parser, execParser,
   subparser, command, info, infoOption, long, short, help, value,
   progDesc, header, metavar, helper, (<**>),
-  many, strArgument, strOption, flag, auto, fullDesc)
+  many, strArgument, strOption, flag, fullDesc)
 
 
 data Command
@@ -55,8 +55,8 @@ distParser = Dist <$>
 
 main :: IO ()
 main = do
-   command <- execParser commandParserInfo
-   case command of
+   com <- execParser commandParserInfo
+   case com of
      Build shouldPreprocess paths -> build ShouldCompile shouldPreprocess paths
      CreateEnv -> createEnv
      Update cmd -> update cmd

--- a/fragnix.cabal
+++ b/fragnix.cabal
@@ -63,7 +63,7 @@ executable fragnix
                        fragnix
   hs-source-dirs:      app
   default-language:    Haskell2010
-  ghc-options:         -O2 -threaded -rtsopts
+  ghc-options:         -O2 -threaded -rtsopts -Wall
 
 test-suite test
   import:              shared-build-depends


### PR DESCRIPTION
Enables Wall for the executable in the cabal file and fixes the remaining warnings (mostly name shadowing).